### PR TITLE
add platform-specific publisher account example

### DIFF
--- a/full-example/TaboolaReactNativeExample/android/app/src/main/assets/index.android.bundle
+++ b/full-example/TaboolaReactNativeExample/android/app/src/main/assets/index.android.bundle
@@ -89374,13 +89374,17 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _react = _interopRequireWildcard(_$$_REQUIRE(_dependencyMap[3], "react"));
 
-  var _reactNativeTaboola = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[4], "@taboola/react-native-taboola"));
+  var _reactNative = _$$_REQUIRE(_dependencyMap[4], "react-native");
 
-  var _propTypes = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[5], "prop-types"));
+  var _reactNativeTaboola = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[5], "@taboola/react-native-taboola"));
+
+  var _propTypes = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[6], "prop-types"));
 
   var _jsxFileName = "/Users/mark.sauer.utley/Development/_sdk-examples/taboola-react-native-example/full-example/TaboolaReactNativeExample/components/Widget.js";
 
   var Widget = function Widget(props) {
+    var publisher = _reactNative.Platform.OS === 'ios' ? 'sdk-tester' : 'sdk-tester';
+
     var _useState = (0, _react.useState)(0),
         _useState2 = (0, _slicedToArray2.default)(_useState, 2),
         height = _useState2[0],
@@ -89388,7 +89392,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
     return _react.default.createElement(_reactNativeTaboola.default, {
       mode: props.mode,
-      publisher: props.publisher,
+      publisher: publisher,
       pageType: props.pageType,
       pageUrl: props.pageUrl,
       placement: props.placement,
@@ -89401,7 +89405,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
       },
       onDidLoad: function onDidLoad(event) {
         props.onDidLoad(event);
-        setHeight(parseInt(event.nativeEvent.height, 10));
+        setHeight(Number(event.nativeEvent.height));
       },
       onDidFailToLoad: function onDidFailToLoad(event) {
         props.onDidFailToLoad();
@@ -89413,7 +89417,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
       onAdItemClick: function onAdItemClick(event) {},
       __source: {
         fileName: _jsxFileName,
-        lineNumber: 9,
+        lineNumber: 14,
         columnNumber: 3
       }
     });
@@ -89421,7 +89425,6 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   Widget.defaultProps = {
     mode: 'alternating-widget-without-video-1-on-1',
-    publisher: 'sdk-tester',
     pageType: 'article',
     pageUrl: 'https://blog.taboola.com',
     placement: 'Mid Article',
@@ -89430,7 +89433,6 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
   };
   Widget.propTypes = {
     mode: _propTypes.default.string.isRequired,
-    publisher: _propTypes.default.string.isRequired,
     pageType: _propTypes.default.string.isRequired,
     pageUrl: _propTypes.default.string.isRequired,
     placement: _propTypes.default.string.isRequired,
@@ -89439,7 +89441,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
   };
   var _default = Widget;
   exports.default = _default;
-},429,[1,430,431,50,435,66],"components/Widget.js");
+},429,[1,430,431,50,2,435,66],"components/Widget.js");
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   var _typeof = _$$_REQUIRE(_dependencyMap[0], "../helpers/typeof");
 
@@ -97202,6 +97204,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
   var _jsxFileName = "/Users/mark.sauer.utley/Development/_sdk-examples/taboola-react-native-example/full-example/TaboolaReactNativeExample/components/Feed.js";
 
   var Feed = function Feed(props) {
+    var publisher = _reactNative.Platform.OS === 'ios' ? 'sdk-tester' : 'sdk-tester';
     var feedHeight = _reactNative.Dimensions.get('window').height * 2;
 
     var _useState = (0, _react.useState)(feedHeight),
@@ -97212,7 +97215,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
     return _react.default.createElement(_reactNativeTaboola.default, {
       viewID: props.viewID,
       mode: props.mode,
-      publisher: props.publisher,
+      publisher: publisher,
       pageType: props.pageType,
       pageUrl: props.pageUrl,
       placement: props.placement,
@@ -97234,7 +97237,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
       onAdItemClick: function onAdItemClick(event) {},
       __source: {
         fileName: _jsxFileName,
-        lineNumber: 12,
+        lineNumber: 17,
         columnNumber: 5
       }
     });
@@ -97242,7 +97245,6 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   Feed.defaultProps = {
     mode: 'thumbs-feed-01',
-    publisher: 'sdk-tester',
     pageType: 'article',
     pageUrl: 'https://blog.taboola.com',
     placement: 'Feed without video',
@@ -97250,7 +97252,6 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
   };
   Feed.propTypes = {
     mode: _propTypes.default.string.isRequired,
-    publisher: _propTypes.default.string.isRequired,
     pageType: _propTypes.default.string.isRequired,
     pageUrl: _propTypes.default.string.isRequired,
     placement: _propTypes.default.string.isRequired,

--- a/full-example/TaboolaReactNativeExample/components/Feed.js
+++ b/full-example/TaboolaReactNativeExample/components/Feed.js
@@ -1,9 +1,14 @@
-import React, {useState} from 'react';
-import {Dimensions} from 'react-native';
+import React, { useState } from 'react';
+import { Dimensions, Platform } from 'react-native';
 import RNTaboolaView from '@taboola/react-native-taboola';
 import PropTypes from 'prop-types';
 
-const Feed = props => {
+const Feed = (props) => {
+  // Set the publisher according to the OS. 
+	// Taboola will provide a publisher id for android and one for ios.
+	// Here we are just using the test account for both.
+	const publisher = Platform.OS === 'ios' ? 'sdk-tester' : 'sdk-tester';
+
   // Get the dimensions of the screen and set the feed height to twice the screen height
   const feedHeight = Dimensions.get('window').height * 2;
   const [height, setHeight] = useState(feedHeight);
@@ -12,7 +17,7 @@ const Feed = props => {
     <RNTaboolaView
       viewID={props.viewID}
       mode={props.mode}
-      publisher={props.publisher}
+      publisher={publisher}
       pageType={props.pageType}
       pageUrl={props.pageUrl}
       placement={props.placement}
@@ -36,9 +41,7 @@ const Feed = props => {
 };
 
 Feed.defaultProps = {
-  //mode: 'thumbnails-a',
   mode: 'thumbs-feed-01',
-  publisher: 'sdk-tester',
   pageType: 'article',
   pageUrl: 'https://blog.taboola.com',
   placement: 'Feed without video',
@@ -47,7 +50,6 @@ Feed.defaultProps = {
 
 Feed.propTypes = {
   mode: PropTypes.string.isRequired,
-  publisher: PropTypes.string.isRequired,
   pageType: PropTypes.string.isRequired,
   pageUrl: PropTypes.string.isRequired,
   placement: PropTypes.string.isRequired,

--- a/full-example/TaboolaReactNativeExample/components/Widget.js
+++ b/full-example/TaboolaReactNativeExample/components/Widget.js
@@ -1,14 +1,19 @@
 import React, { useState } from 'react';
+import { Platform } from 'react-native';
 import RNTaboolaView from '@taboola/react-native-taboola';
 import PropTypes from 'prop-types';
 
-const Widget = props => {
+const Widget = (props) => {
+	// Set the publisher according to the OS. 
+	// Taboola will provide a publisher id for android and one for ios.
+	// Here we are just using the test account for both.
+	const publisher = Platform.OS === 'ios' ? 'sdk-tester' : 'sdk-tester';
 	const [height, setHeight] = useState(0);
 
 	return (
 		<RNTaboolaView
 			mode={props.mode}
-			publisher={props.publisher}
+			publisher={publisher}
 			pageType={props.pageType}
 			pageUrl={props.pageUrl}
 			placement={props.placement}
@@ -23,7 +28,7 @@ const Widget = props => {
 				// This lets us implement other logic into this callback via props
 				props.onDidLoad(event);
 				// Set the height of the widget dynamically
-				setHeight(parseInt(event.nativeEvent.height, 10));
+				setHeight(Number(event.nativeEvent.height));
 			}}
 			onDidFailToLoad={event => {
 				props.onDidFailToLoad();
@@ -40,7 +45,6 @@ const Widget = props => {
 
 Widget.defaultProps = {
 	mode: 'alternating-widget-without-video-1-on-1',
-	publisher: 'sdk-tester',
 	pageType: 'article',
 	pageUrl: 'https://blog.taboola.com',
 	placement: 'Mid Article',
@@ -50,7 +54,6 @@ Widget.defaultProps = {
 
 Widget.propTypes = {
 	mode: PropTypes.string.isRequired,
-	publisher: PropTypes.string.isRequired,
 	pageType: PropTypes.string.isRequired,
 	pageUrl: PropTypes.string.isRequired,
 	placement: PropTypes.string.isRequired,


### PR DESCRIPTION
We always have one publisher account for Android and another for iOS, so I added examples showing publishers how to differentiate by platform.